### PR TITLE
Added support for a check summary and return value

### DIFF
--- a/netwell/checkers.py
+++ b/netwell/checkers.py
@@ -19,6 +19,8 @@ class Output:
         self.quiet = False
         self.line = ''
         self.line_error = False
+        self.total_checks = 0
+        self.failed_checks = 0
 
     def info(self, text):
         if not self.quiet or self.line_error:
@@ -38,6 +40,22 @@ class Output:
         self.line_error = False
         self.line = ''
 
+    @property
+    def return_code(self):
+        """ Get the return code for the summary if you want
+        to use the command result code in external software.
+        """
+        return self.failed_checks
+
+    def summary(self):
+        """ Prints a summary of the checks performed. """
+        self.info('CHECKS={checks}, OK={success}, FAILED={failed}'.format(
+            checks=self.total_checks,
+            success=self.total_checks - self.failed_checks,
+            failed=self.failed_checks
+        ))
+        self.eol()
+
 
 output = Output()
 
@@ -51,11 +69,13 @@ class Outcome:
     def fail(self, message=None):
         self.message = message
         self.failed = True
+        output.failed_checks += 1
         raise RuleFailedException()
 
 
 @contextmanager
 def rule(description):
+    output.total_checks += 1
     output.info(description + '... ')
     outcome = Outcome()
     try:


### PR DESCRIPTION
### Reasoning

I want to use netwell in a jenkins task, knowing that the jenkins task will fail if the checks fail. For this jenkins use the return value of the executed commands in the `execute shell` job task.
### Commit info:
- The `output` class can now output a summary of the passed, failed and total checks.
- The `output` class now have a property that contains a return code based on if there were failed tests.
### Example:

``` python
# -*- coding: utf-8 -*-
from netwell.checkers import URL, output
# ... checks ...
output.summary()
exit(code=output.return_code())
```

```
$ netwell checks.py
...
CHECKS=3, OK=2, FAILED=1
$ echo $?
1
```
