### PR TITLE
Simpler to assert simple text

### DIFF
--- a/netwell/checkers.py
+++ b/netwell/checkers.py
@@ -151,6 +151,34 @@ class URL(Checker):
                     outcome.fail('not found')
         return self
 
+    def has_response_text(self, text):
+        """
+        Checks if the specified text is present in the response body.
+        """
+        with rule(
+                'Checking that {url} response contains {text}'.format(
+                    url=self.url,
+                    text=text)) as outcome:
+
+                    response = self._fetch()
+                    if text not in response.text:
+                        outcome.fail('not found')
+        return self
+    
+    def has_not_response_text(self, text):
+        """
+        Checks if the specified text is not present in the response body.
+        """
+        with rule(
+                'Checking that {url} response does not contains {text}'.format(
+                    url=self.url,
+                    text=text)) as outcome:
+
+                    response = self._fetch()
+                    if text in response.text:
+                        outcome.fail('text found')
+        return self
+
     def check_response(self, func):
         with rule(
                 'Checking that {url} passes {func}'.format(


### PR DESCRIPTION
Two new methods on the `URL` class to make it simpler to assert simple text.
These assertions could also have been accomplished by using the generic `check_response`, but I submit this pull request to decrease the boilerplate and increase the conciseness.

This would make it possible to shorten the following
```
def custom_check(response, outcome):
    if 'det' not in response.text()
        outcome.fail('Other data expected')

URL('http://httpbin.org/get').check_response(custom_check)
```
into
```
URL('http://httpbin.org/get').has_response_text('hello world')
```

I know this might seem a little ridiculous as it is an edge case I am implementing for and the generic `check_response` can do everything. But I find that I use these two checks all the time, and thus makes it worth it.

An alternative approach could be to use the decorator pattern to generate custom checks as part of the netwell library.
Then something like this would be possible:
```
URL('http://httpbin.org/get').check_response(has_response_text('hello world'))
```
If you like the other solution to part of your netwell library, then I can make a PR for that.

Thank you